### PR TITLE
removes the port number from the redirect_uri

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -18,7 +18,7 @@ const {
   scope
 } = config;
 
-const redirect_uri = `${host}:${port}/oauth/redirect`;
+const redirect_uri = `${host}/oauth/redirect`;
 const { errorMap } = require('./customError/errorMap');
 const parser = require('./parser/index');
 const createAction = require('./actions/index');


### PR DESCRIPTION
Right now the redirect URL specified on slack and the one created in the app don't match. This prevents the users from authorizing the app. This change removes the port number to make sure the two URL match.